### PR TITLE
没.env文件，支持docker 环境从环境变量获取，可以继续运行

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"log"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -10,7 +11,7 @@ func init() {
 	// load .env
 	err := godotenv.Load()
 	if err != nil {
-		panic("Error loading .env file")
+		log.Println("No .env file found or error loading .env file")
 	}
 }
 


### PR DESCRIPTION
应用在容器环境中运行，配置应该通过Docker运行命令指定的环境变量进行设置，无需.env文件。然而，当你在本地开发环境中没有设置相应的环境变量时，应用会退回到尝试从.env文件中加载配置